### PR TITLE
Refactor the code to use the execSync API capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ jobs:
       - uses: shopify/shopify-cli-action@v1
         with:
           path: 'scripts/my_script'
-          auth-token: 'xxx'
+          auth-token: ${{ secrets.SHOPIFY_CLI_AUTH_TOKEN }}
           command: 'script push'
 ```

--- a/src/execSync.js
+++ b/src/execSync.js
@@ -1,9 +1,18 @@
 const childProcess = require('child_process');
 
-module.exports = (command) => {
-  const options = {};
+/**
+ * Runs a command synchronously forwarding the stdout and stderr to the current process'
+ * stdout and stderr.
+ *
+ * @param {string} command - The command to be executed
+ * @param {*} options - An object with options to be passed to childProcess.execSync
+ * @param {*} env - An object containing a set of env. variables to extend the process'.
+ */
+module.exports = (command, options = {}, env = {}) => {
+  const extendedOptions = { ...options };
   if (!process.env.JEST_WORKER_ID) {
-    options.stdio = 'inherit';
+    extendedOptions.stdio = 'inherit';
   }
-  childProcess.execSync(command, options);
+  extendedOptions.env = { ...env, ...process.env };
+  childProcess.execSync(command, extendedOptions);
 };

--- a/src/execSync.test.js
+++ b/src/execSync.test.js
@@ -9,12 +9,19 @@ describe('execSync', () => {
     childProcess.execSync = jest.fn();
 
     // When
-    execSync('shopify command');
+    execSync(
+      'shopify command',
+      { cwd: '/path' },
+      { MY_VARIABLE: 'VALUE' },
+    );
 
     // Then
     expect(childProcess.execSync).toHaveBeenCalledWith(
       'shopify command',
-      {},
+      {
+        cwd: '/path',
+        env: { MY_VARIABLE: 'VALUE', ...process.env },
+      },
     );
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,11 @@ module.exports = () => {
   try {
     execSync('gem install shopify-cli');
     const path = input.path() || '.';
-    const envVars = input.authToken()
-      ? `SHOPIFY_CLI_AUTH_TOKEN=${input.authToken()}`
-      : '';
-    execSync(`cd ${path} && ${envVars} shopify ${input.command()}`);
+    const env = {};
+    if (input.authToken()) {
+      env.SHOPIFY_CLI_AUTH_TOKEN = input.authToken();
+    }
+    execSync(`shopify ${input.command()}`, { cwd: path }, env);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,9 @@ const input = require('./input');
 module.exports = () => {
   try {
     execSync('gem install shopify-cli');
-    let cwd;
-    if (input.path()) {
-      cwd = path.resolve(input.path());
-    } else {
-      cwd = process.cwd();
-    }
+    const cwd = input.path()
+      ? path.resolve(input.path())
+      : process.cwd();
     const env = {};
     if (input.authToken()) {
       env.SHOPIFY_CLI_AUTH_TOKEN = input.authToken();

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,22 @@
 const core = require('@actions/core');
+const path = require('path');
 const execSync = require('./execSync');
 const input = require('./input');
 
 module.exports = () => {
   try {
     execSync('gem install shopify-cli');
-    const path = input.path() || '.';
+    let cwd;
+    if (input.path()) {
+      cwd = path.resolve(input.path());
+    } else {
+      cwd = process.cwd();
+    }
     const env = {};
     if (input.authToken()) {
       env.SHOPIFY_CLI_AUTH_TOKEN = input.authToken();
     }
-    execSync(`shopify ${input.command()}`, { cwd: path }, env);
+    execSync(`shopify ${input.command()}`, { cwd }, env);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
I'm refactoring some code to leverage the `child_process.execSync` API to pass environment variables and set the working directory. I've also taken the opportunity to change the example in the README to read the token using the GitHub Actions' secrets functionality. 