### PR TITLE
Using sudo to install shopify-cli

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const input = require('./input');
 
 module.exports = () => {
   try {
-    execSync('gem install shopify-cli');
+    execSync('sudo gem install shopify-cli');
     const cwd = input.path()
       ? path.resolve(input.path())
       : process.cwd();


### PR DESCRIPTION
I was running into permission errors on Github actions when using this packae.

<img width="577" alt="image" src="https://user-images.githubusercontent.com/6590647/165768957-9294877b-5694-4012-8592-fd02032eea05.png">

Adding `sudo` to install command fixes this problem. I hope this helps.
